### PR TITLE
pin typescript to v5 and fix CRA dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@engi.network/design-matcher",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@engi.network/design-matcher",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -29,7 +29,7 @@
         "react-scripts": "5.0.1",
         "sharp": "^0.32.1",
         "tailwindcss": "^3.3.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.1.6",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -26971,15 +26971,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@engi.network/design-matcher",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
@@ -22,7 +22,7 @@
     "react-scripts": "5.0.1",
     "sharp": "^0.32.1",
     "tailwindcss": "^3.3.2",
-    "typescript": "^4.9.5",
+    "typescript": "^5.1.6",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -90,5 +90,10 @@
   "bugs": {
     "url": "https://github.com/engi-network/design-matcher/issues"
   },
-  "homepage": "https://github.com/engi-network/design-matcher#readme"
+  "homepage": "https://github.com/engi-network/design-matcher#readme",
+  "overrides": {
+    "react-scripts": {
+      "typescript": "^5"
+    }
+  }
 }


### PR DESCRIPTION
`create-react-app` is dead and the typescript dependency needs to be overridden to support v5.